### PR TITLE
Installing cross browsers

### DIFF
--- a/images/win/scripts/Installers/Install-Chrome.ps1
+++ b/images/win/scripts/Installers/Install-Chrome.ps1
@@ -1,0 +1,15 @@
+################################################################################
+##  File:  Install-Chrome.ps1
+##  Team:  Automated Testing
+##  Desc:  Install Google Chrome
+################################################################################
+
+$temp_install_dir = 'C:\Windows\Installer'
+New-Item -Path $temp_install_dir -ItemType Directory -Force
+
+choco install googlechrome
+
+New-Item -Path "HKLM:\SOFTWARE\Policies\Google\Update" -Force
+New-ItemProperty "HKLM:\SOFTWARE\Policies\Google\Update" -Name "AutoUpdateCheckPeriodMinutes" -Value 00000000 -Force
+New-Item -Path "HKLM:\SOFTWARE\Policies\Google\Chrome" -Force
+New-ItemProperty "HKLM:\SOFTWARE\Policies\Google\Chrome" -Name "DefaultBrowserSettingEnabled" -Value 00000000 -Force

--- a/images/win/scripts/Installers/Install-Firefox.ps1
+++ b/images/win/scripts/Installers/Install-Firefox.ps1
@@ -1,0 +1,16 @@
+################################################################################
+##  File:  Install-Firefox.ps1
+##  Team:  Automated Testing
+##  Desc:  Install Mozilla Firefox
+################################################################################
+
+choco install firefox
+
+$path = '{0}\Program Files\Mozilla Firefox\' -f $env:SystemDrive;
+New-Item -path $path -Name 'mozilla.cfg' -Value '//
+pref("browser.shell.checkDefaultBrowser", false);
+pref("app.update.enabled", false);' -ItemType file -force
+
+$path = '{0}\Program Files\Mozilla Firefox\defaults\pref\' -f $env:SystemDrive;
+New-Item -path $path -Name 'local-settings.js' -Value 'pref("general.config.obscure_value", 0);
+pref("general.config.filename", "mozilla.cfg");' -ItemType file -force

--- a/images/win/scripts/Installers/Validate-Chrome.ps1
+++ b/images/win/scripts/Installers/Validate-Chrome.ps1
@@ -6,8 +6,7 @@
 
 if(Test-Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe")
 {
-	$path = Get-ChildItem "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe" | Get-ItemProperty -Name Path
-	Write-Host "Google Chrome installed at " $path
+	(Get-Item (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe').'(Default)').VersionInfo
 	exit 0
 }
 else

--- a/images/win/scripts/Installers/Validate-Chrome.ps1
+++ b/images/win/scripts/Installers/Validate-Chrome.ps1
@@ -1,0 +1,17 @@
+################################################################################
+##  File:  Validate-Chrome.ps1
+##  Team:  Automated Testing
+##  Desc:  Validate Google Chrome installation.
+################################################################################
+
+if(Test-Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe")
+{
+	$path = Get-ChildItem "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe" | Get-ItemProperty -Name Path
+	Write-Host "Google Chrome installed at " $path
+	exit 0
+}
+else
+{
+	Write-Host "Google Chrome is not isntalled."
+    exit 1
+}

--- a/images/win/scripts/Installers/Validate-Firefox.ps1
+++ b/images/win/scripts/Installers/Validate-Firefox.ps1
@@ -6,8 +6,7 @@
 
 if(Test-Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\firefox.exe")
 {
-	$path = (Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\firefox.exe").Path
-	Write-Host "Mozilla Firefox installed at " $path
+	(Get-Item (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\firefox.exe').'(Default)').VersionInfo
 	exit 0
 }
 else

--- a/images/win/scripts/Installers/Validate-Firefox.ps1
+++ b/images/win/scripts/Installers/Validate-Firefox.ps1
@@ -1,0 +1,17 @@
+################################################################################
+##  File:  Validate-Firefox.ps1
+##  Team:  Automated Testing
+##  Desc:  Validate Mozilla Firefox installation.
+################################################################################
+
+if(Test-Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\firefox.exe")
+{
+	$path = (Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\firefox.exe").Path
+	Write-Host "Mozilla Firefox installed at " $path
+	exit 0
+}
+else
+{
+	Write-Host "Mozilla Firefox is not installed."
+    exit 1
+}

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -252,12 +252,6 @@
         {
             "type": "powershell",
             "scripts":[
-                "{{ template_dir }}/scripts/Installers/Vs2017/Install-Wix.ps1"
-            ]
-        },
-        {
-            "type": "powershell",
-            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-NodeLts.ps1"
             ]
         },

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -222,6 +222,18 @@
         {
             "type": "powershell",
             "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Chrome.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-Firefox.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-Wix.ps1"
             ]
         },
@@ -315,6 +327,18 @@
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Svn.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Chrome.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-Firefox.ps1"
             ]
         },
         {


### PR DESCRIPTION
Installing chrome and firefox, and dismissing the initial prompts, to enable users to do cross browser testing on hosted agents.

Testing done:
Validated E2E by creating the image, spinning a VM, setting up a build agent and running a build definition to run selenium tests on all browers. Here is a [link](https://mseng.visualstudio.com/VSOnline/_build/index?buildId=5065539&_a=summary&tab=ms.vss-test-web.test-result-details)