### PR TITLE
Fix for SSDT and Wix validation issues with VS 2017 15.6

### DIFF
--- a/images/win/scripts/Installers/Vs2017/Validate-SSDT.ps1
+++ b/images/win/scripts/Installers/Vs2017/Validate-SSDT.ps1
@@ -16,7 +16,7 @@ function Get-SSDTExtensionPackage {
         exit 1
     }
 
-    $stateContent = Get-Content -Path ($instanceFolders.FullName + '\state.json')
+    $stateContent = Get-Content -Path ($instanceFolders.FullName + '\state.packages.json')
     $state = $stateContent | ConvertFrom-Json
     $SsdtPackage = $state.packages | where { $_.id -eq "SSDT" }
     return $SsdtPackage

--- a/images/win/scripts/Installers/Vs2017/Validate-Wix.ps1
+++ b/images/win/scripts/Installers/Vs2017/Validate-Wix.ps1
@@ -23,7 +23,7 @@ function Get-WixExtensionPackage {
         exit 1
     }
 
-    $stateContent = Get-Content -Path ($instanceFolders.FullName + '\state.json')
+    $stateContent = Get-Content -Path ($instanceFolders.FullName + '\state.packages.json')
     $state = $stateContent | ConvertFrom-Json
     $WixPackage = $state.packages | where { $_.id -eq "WixToolset.VisualStudioExtension.Dev15" }
     return $WixPackage


### PR DESCRIPTION
In VS 2017 15.6, the package array has apparently been moved from state.json to state.packages.json, causing the SSDT and Wix validation scripts to fail.  Upon pointing the scripts to the state.packages.json file, the validation passes. 

To test this, I evaluated a state.packages.json file that did not have Wix installed, and Wix did not appear in the file, whereas an installation that did have Wix installed contained an entry for it in state.packages.json.