### PR TITLE
Added Chocolatey to list of installed software

### DIFF
--- a/images/win/Vs2017-Server2016-Readme.md
+++ b/images/win/Vs2017-Server2016-Readme.md
@@ -452,3 +452,9 @@ _Runtime:_
 _Version:_ 5.7.21.0<br/>
 _Environment:_
 * PATH: contains location of mysql.exe
+
+## Chocolatey
+
+_Version:_ 0.10.8
+_Environment:_
+* PATH: contains location for choco.exe


### PR DESCRIPTION
- Based on this Stack Overflow question:

https://stackoverflow.com/questions/49294430/how-to-run-or-install-tool-on-hosted-agent-in-vsts

and a follow up conversation with Buck Hodges on Twitter:

https://twitter.com/tfsbuck/status/974392503414685697

I thought it made sense to add Chocolatey to this list, so that people are aware that it is already available on the Hosted 2017 Build Agent.