### PR TITLE
Changed the download URL for the vcredist to HTTPS

### DIFF
--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -10,7 +10,7 @@ $uri = 'https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.21-winx64.zip'
 $mysqlPath = 'C:\mysql-5.7.21-winx64\bin'
 
 # Installing visual c++ redistibutable package.
-$InstallerURI = 'http://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe'
+$InstallerURI = 'https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe'
 $InstallerName = 'vcredist_x64.exe'
 $ArgumentList = ('/install', '/quiet', '/norestart' )
 


### PR DESCRIPTION
I have been using this packer model to create my own private build agent VM images using a local Hyper-V box.

The process was repeatedly failing on the validate MySQL stage. After checking the logs I found the issue was the install MySQL step was failing without stopping the packer process

```
==> hyperv-iso: Provisioning with powershell script: C:\vsts-image-generation\images\win/scripts/Installers/Install-MysqlCli.ps1
    hyperv-iso: Downloading vcredist_x64.exe...
    hyperv-iso: Failed to install the Executable vcredist_x64.exe
    hyperv-iso: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.
    hyperv-iso: -1
``` 

On further investigation I found the problem was the **Invoke-WebRequest** that was meant to download the **vcredist_x64.exe** file was downloading a 1Kb file, not the 7Mb file it was meant to. This was obviously failing to install. 

The fix on my system it turned out was to use the HTTPS download URL for the file as opposed to HTTP

I accept this seems strange, especially as using the HTTP URL (from the PowerShell prompt) on another PC worked fine. But it seems a sensible step to use HTTPS anyway hence the PR