### PR TITLE
Install MinGW

### DIFF
--- a/images/win/scripts/Installers/Install-MinGW.ps1
+++ b/images/win/scripts/Installers/Install-MinGW.ps1
@@ -4,7 +4,7 @@
 ##  Desc:  Install GNU tools for Windows to C:\tools\mingw64
 ################################################################################
 
-Import-Module -Name PathHelpers -Force
+Import-Module -Name ImageHelpers -Force
 
 choco install -y mingw
 $installDir = "C:\tools\mingw64\bin"

--- a/images/win/scripts/Installers/Install-MinGW.ps1
+++ b/images/win/scripts/Installers/Install-MinGW.ps1
@@ -1,0 +1,15 @@
+################################################################################
+##  File:  Install-MinGW.ps1
+##  Team:  CI-X
+##  Desc:  Install GNU tools for Windows to C:\tools\mingw64
+################################################################################
+
+Import-Module -Name PathHelpers -Force
+
+choco install -y mingw
+$installDir = "C:\tools\mingw64\bin"
+Add-MachinePathItem $installDir
+
+# Hard link mingw32-make.exe to make.exe, which is a more discoverable name
+# and so the same command line can be used on Windows as on macOS and Linux
+New-Item -Path $installDir -ItemType HardLink -Name "make.exe" -Value "$installDir\mingw32-make.exe"

--- a/images/win/scripts/Installers/Validate-MinGW.ps1
+++ b/images/win/scripts/Installers/Validate-MinGW.ps1
@@ -1,0 +1,41 @@
+if (Get-Command -Name 'g++')
+{
+    Write-Host "g++ is successfully installed:"
+    g++ --version | Write-Host
+}
+else
+{
+    Write-Host "g++ is not on PATH"
+    exit 1
+}
+
+if (Get-Command -Name 'make')
+{
+    Write-Host "make is successfully installed:"
+    make --version | Write-Host
+}
+else
+{
+    Write-Host "make is not on PATH"
+    exit 1
+}
+
+# Adding description of the software to Markdown
+
+# `g++ --version` gives output like:
+# g++.exe (x86_64-posix-seh-rev0, Built by MinGW-W64 project) 5.3.0
+# Copyright (C) 2015 Free Software Foundation, Inc.
+# This is free software; see the source for copying conditions.  There is NO
+# warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+$SoftwareName = "MinGW"
+$(g++ --version).Split([System.Environment]::NewLine)[0] -match "\d\.\d\.\d$"
+$minGwVersion = $matches[0]
+
+$Description = @"
+_Version:_ $minGwVersion<br/>
+_Environment:_
+* PATH: contains location of the MinGW 'bin' directory
+"@
+
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description

--- a/images/win/scripts/Installers/Validate-MinGW.ps1
+++ b/images/win/scripts/Installers/Validate-MinGW.ps1
@@ -1,3 +1,14 @@
+if (Get-Command -Name 'gcc')
+{
+    Write-Host "gcc is successfully installed:"
+    gcc --version | Write-Host
+}
+else
+{
+    Write-Host "gcc is not on PATH"
+    exit 1
+}
+
 if (Get-Command -Name 'g++')
 {
     Write-Host "g++ is successfully installed:"
@@ -22,14 +33,14 @@ else
 
 # Adding description of the software to Markdown
 
-# `g++ --version` gives output like:
-# g++.exe (x86_64-posix-seh-rev0, Built by MinGW-W64 project) 5.3.0
+# `gcc --version` gives output like:
+# gcc.exe (x86_64-posix-seh-rev0, Built by MinGW-W64 project) 5.3.0
 # Copyright (C) 2015 Free Software Foundation, Inc.
 # This is free software; see the source for copying conditions.  There is NO
 # warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 $SoftwareName = "MinGW"
-$(g++ --version).Split([System.Environment]::NewLine)[0] -match "\d\.\d\.\d$"
+$(gcc --version).Split([System.Environment]::NewLine)[0] -match "\d\.\d\.\d$"
 $minGwVersion = $matches[0]
 
 $Description = @"

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -287,7 +287,7 @@
                 "{{ template_dir }}/scripts/Installers/Update-AndroidSDK.ps1"
             ]
         },
-	{
+        {
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-MysqlCli.ps1"
@@ -321,10 +321,16 @@
                 "{{ template_dir }}/scripts/Installers/Install-AzureModules.ps1"
             ]
         },
-	{
+        {
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Update-DotnetTLS.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Install-MinGW.ps1"
             ]
         },
         {
@@ -409,16 +415,22 @@
                 "{{ template_dir }}/scripts/Installers/Validate-DotnetSDK.ps1"
             ]
         },
-  	{
+        {
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-MysqlCli.ps1"
             ]
         },
-	{
+        {
             "type": "powershell",
             "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DotnetTLS.ps1"
+            ]
+        },
+        {
+            "type": "powershell",
+            "scripts":[
+                "{{ template_dir }}/scripts/Installers/Validate-MinGW.ps1"
             ]
         },
         {


### PR DESCRIPTION
MinGW contains GNU build tools -- most importantly GCC and Make.  Both of these are needed for C and C++ support as well as Python support.