### PR TITLE
Fix for intermittent sysprep issues

### DIFF
--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -10,6 +10,7 @@
         "location": "{{env `ARM_RESOURCE_LOCATION`}}",
         "ssh_password": "{{env `SSH_PASSWORD`}}",
         "vm_size": "Standard_DS4_v2",
+
         "image_folder": "C:\\image",
         "commit_file": "C:\\image\\commit.txt",
         "metadata_file": "C:\\image\\metadata.txt",
@@ -27,6 +28,7 @@
             "subscription_id": "{{user `subscription_id`}}",
             "object_id": "{{user `object_id`}}",
             "tenant_id": "{{user `tenant_id`}}",
+
             "location": "{{user `location`}}",
             "vm_size": "{{user `vm_size`}}",
             "resource_group_name": "{{user `resource_group`}}",
@@ -47,7 +49,7 @@
     "provisioners": [
         {
             "type": "powershell",
-            "inline": [
+            "inline":[
                 "New-Item -Path {{user `image_folder`}} -ItemType Directory -Force",
                 "Write-Output {{user `commit_id`}} > {{user `commit_file`}}",
                 "Write-Host (Get-Content -Path {{user `commit_file`}})"
@@ -61,7 +63,7 @@
         {
             "type": "windows-shell",
             "inline": [
-                "net user {{user `install_user`}} {{user `install_password`}} /add /passwordchg:no /passwordreq:yes /active:yes",
+                "net user {{user `install_user`}} {{user `install_password`}} /add /passwordchg:no /passwordreq:yes /active:yes" ,
                 "net localgroup Administrators {{user `install_user`}} /add",
                 "winrm set winrm/config/service/auth @{Basic=\"true\"}",
                 "winrm get winrm/config/service/auth"
@@ -69,7 +71,7 @@
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Initialize-VM.ps1"
             ]
         },
@@ -79,7 +81,7 @@
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-ContainersFeature.ps1"
             ]
         },
@@ -89,7 +91,7 @@
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-Docker.ps1"
             ]
         },
@@ -99,13 +101,13 @@
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Validate-Docker.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Update-DockerImages.ps1"
             ]
         },
@@ -115,7 +117,7 @@
                 0,
                 3010
             ],
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-VS2017.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
@@ -131,7 +133,7 @@
                 0,
                 3010
             ],
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-SSDT.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
@@ -143,7 +145,7 @@
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-Wix.ps1"
             ]
         },
@@ -153,7 +155,7 @@
                 0,
                 3010
             ],
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-NET471.ps1"
             ]
         },
@@ -163,19 +165,19 @@
                 0,
                 3010
             ],
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-NET471DevPack.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-ServiceFabricSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-Python.ps1"
             ]
         },
@@ -185,163 +187,161 @@
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Validate-SSDT.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Validate-Wix.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-NET471.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ServiceFabricSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Python.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-AzureCli.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Git.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Go.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Svn.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Chrome.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Firefox.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-SeleniumWebDrivers.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-NodeLts.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-JavaTools.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Cmake.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-DACFx.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Update-AndroidSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-MysqlCli.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-SQLPowerShellTools.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-DotnetSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
             ]
         },
         {
             "type": "windows-shell",
-            "inline": [
-                "wmic product where \"name like '%%microsoft azure powershell%%'\" call uninstall /nointeractive"
-            ]
+            "inline": ["wmic product where \"name like '%%microsoft azure powershell%%'\" call uninstall /nointeractive"]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-AzureModules.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Update-DotnetTLS.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-MinGW.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-TypeScript.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Install-Miniconda.ps1"
             ]
         },
@@ -351,109 +351,109 @@
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-AzureModules.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-AzureCli.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Git.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Go.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Svn.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Chrome.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Firefox.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-SeleniumWebDrivers.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-NodeLts.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-JavaTools.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Cmake.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DACFx.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DotnetSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-MysqlCli.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-DotnetTLS.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-MinGW.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-TypeScript.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-Miniconda.ps1"
             ]
         },
@@ -465,19 +465,19 @@
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Finalize-VM.ps1"
             ]
         },
@@ -487,7 +487,7 @@
         },
         {
             "type": "powershell",
-            "scripts": [
+            "scripts":[
                 "{{ template_dir }}/scripts/Installers/Vs2017/Run-Antivirus.ps1"
             ]
         },

--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -10,7 +10,6 @@
         "location": "{{env `ARM_RESOURCE_LOCATION`}}",
         "ssh_password": "{{env `SSH_PASSWORD`}}",
         "vm_size": "Standard_DS4_v2",
-
         "image_folder": "C:\\image",
         "commit_file": "C:\\image\\commit.txt",
         "metadata_file": "C:\\image\\metadata.txt",
@@ -28,7 +27,6 @@
             "subscription_id": "{{user `subscription_id`}}",
             "object_id": "{{user `object_id`}}",
             "tenant_id": "{{user `tenant_id`}}",
-
             "location": "{{user `location`}}",
             "vm_size": "{{user `vm_size`}}",
             "resource_group_name": "{{user `resource_group`}}",
@@ -49,7 +47,7 @@
     "provisioners": [
         {
             "type": "powershell",
-            "inline":[
+            "inline": [
                 "New-Item -Path {{user `image_folder`}} -ItemType Directory -Force",
                 "Write-Output {{user `commit_id`}} > {{user `commit_file`}}",
                 "Write-Host (Get-Content -Path {{user `commit_file`}})"
@@ -63,7 +61,7 @@
         {
             "type": "windows-shell",
             "inline": [
-                "net user {{user `install_user`}} {{user `install_password`}} /add /passwordchg:no /passwordreq:yes /active:yes" ,
+                "net user {{user `install_user`}} {{user `install_password`}} /add /passwordchg:no /passwordreq:yes /active:yes",
                 "net localgroup Administrators {{user `install_user`}} /add",
                 "winrm set winrm/config/service/auth @{Basic=\"true\"}",
                 "winrm get winrm/config/service/auth"
@@ -71,7 +69,7 @@
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Initialize-VM.ps1"
             ]
         },
@@ -81,7 +79,7 @@
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-ContainersFeature.ps1"
             ]
         },
@@ -91,7 +89,7 @@
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-Docker.ps1"
             ]
         },
@@ -101,13 +99,13 @@
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Validate-Docker.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Update-DockerImages.ps1"
             ]
         },
@@ -117,7 +115,7 @@
                 0,
                 3010
             ],
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-VS2017.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
@@ -133,7 +131,7 @@
                 0,
                 3010
             ],
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-SSDT.ps1"
             ],
             "elevated_user": "{{user `install_user`}}",
@@ -145,7 +143,7 @@
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-Wix.ps1"
             ]
         },
@@ -155,7 +153,7 @@
                 0,
                 3010
             ],
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-NET471.ps1"
             ]
         },
@@ -165,19 +163,19 @@
                 0,
                 3010
             ],
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-NET471DevPack.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-ServiceFabricSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Install-Python.ps1"
             ]
         },
@@ -187,161 +185,163 @@
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Validate-SSDT.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Validate-Wix.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-NET471.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-ServiceFabricSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-Python.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-AzureCli.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Git.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Go.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Svn.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Chrome.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Firefox.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-SeleniumWebDrivers.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-NodeLts.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-JavaTools.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Cmake.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-DACFx.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Update-AndroidSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-MysqlCli.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-SQLPowerShellTools.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-DotnetSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1"
             ]
         },
         {
             "type": "windows-shell",
-            "inline": ["wmic product where \"name like '%%microsoft azure powershell%%'\" call uninstall /nointeractive"]
+            "inline": [
+                "wmic product where \"name like '%%microsoft azure powershell%%'\" call uninstall /nointeractive"
+            ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-AzureModules.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Update-DotnetTLS.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-MinGW.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-TypeScript.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-Miniconda.ps1"
             ]
         },
@@ -351,109 +351,109 @@
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-AzureModules.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-AzureCli.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-Git.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-Go.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-Svn.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-Chrome.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-Firefox.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-SeleniumWebDrivers.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-NodeLts.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-JavaTools.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-Cmake.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-DACFx.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-DotnetSDK.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-MysqlCli.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-DotnetTLS.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-MinGW.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-TypeScript.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-Miniconda.ps1"
             ]
         },
@@ -465,19 +465,19 @@
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Download-ToolCache.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Validate-ToolCache.ps1"
             ]
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Finalize-VM.ps1"
             ]
         },
@@ -487,7 +487,7 @@
         },
         {
             "type": "powershell",
-            "scripts":[
+            "scripts": [
                 "{{ template_dir }}/scripts/Installers/Vs2017/Run-Antivirus.ps1"
             ]
         },
@@ -495,7 +495,8 @@
             "type": "powershell",
             "inline": [
                 "if( Test-Path $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml -Force}",
-                "& $Env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /shutdown /quiet"
+                "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit",
+                "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
             ]
         }
     ]


### PR DESCRIPTION
When building the Windows Server 2016 VS2017 image, I've been running into intermittent sysprep issues where the image appears to have been created successfully, but when the image is used for a VM, the VM does not start successfully.  This has happened both with VHD images and with managed images (I'm using the VM size "Standard_F8s_v2" to build the images).  Changing the sysprep step to adhere to Microsoft's latest recommendations for creating a managed image appears to fix the issue.  Instead of shutting down immediately after running sysprep, it loops until the image state is correct.  Here is the example where I copied this change from: https://github.com/hashicorp/packer/blob/master/examples/azure/windows_custom_image.json  