### PR TITLE
Enable TLS 1.2 before downloading from dev.mysql.com

### DIFF
--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -17,7 +17,7 @@ $ArgumentList = ('/install', '/quiet', '/norestart' )
 $exitCode = Install-EXE -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentList
 if ($exitCode -eq 0 -or $exitCode -eq 3010)
 {
-    # MySQL disabled TLS 1.0 support on or about Jul-14-2018.  Need to make sure TLS 1.2 is enalbed.
+    # MySQL disabled TLS 1.0 support on or about Jul-14-2018.  Need to make sure TLS 1.2 is enabled.
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 
     # Get the latest mysql command line tools .

--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -17,6 +17,9 @@ $ArgumentList = ('/install', '/quiet', '/norestart' )
 $exitCode = Install-EXE -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentList
 if ($exitCode -eq 0 -or $exitCode -eq 3010)
 {
+    # MySQL disabled TLS 1.0 support on or about Jul-14-2018.  Need to make sure TLS 1.2 is enalbed.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
+
     # Get the latest mysql command line tools .
     Invoke-WebRequest -UseBasicParsing -Uri $uri -OutFile mysql.zip
 


### PR DESCRIPTION
Install-MysqlCli.ps1 fails with the error message:
"vhd: Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel."