### PR TITLE
Add Python versions to Markdown

### DIFF
--- a/images/win/scripts/Installers/Validate-ToolCache.ps1
+++ b/images/win/scripts/Installers/Validate-ToolCache.ps1
@@ -40,3 +40,21 @@ foreach ($version in $pythonVersions)
         exit 1
     }
 }
+
+# Adding description of the software to Markdown
+$SoftwareName = "Python"
+$Description = ""
+
+foreach ($version in $pythonVersions)
+{
+    $v = $version[0]
+    $arch = $version[1]
+    $Description += "_Version:_ $v ($arch)<br/>"
+}
+
+$Description += @"
+<br/>
+> Note: These versions of Python are available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task.
+"@
+
+Add-SoftwareDetailsToMarkdown -SoftwareName $SoftwareName -DescriptionMarkdown $Description


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33549821/42951557-72b800ca-8b44-11e8-9220-8696db4a421f.png)

We now have two Python sections, the previous one coming from the list of software installed with Visual Studio.  I added "Note: These versions of Python are available through the Use Python Version task" to try to clarify.