### PR TITLE
confirmation password >14 and test install_user part of admin group

### DIFF
--- a/images/win/vs2017-Server2016-Azure.json
+++ b/images/win/vs2017-Server2016-Azure.json
@@ -63,10 +63,16 @@
         {
             "type": "windows-shell",
             "inline": [
-                "net user {{user `install_user`}} {{user `install_password`}} /add /passwordchg:no /passwordreq:yes /active:yes" ,
+                "net user {{user `install_user`}} {{user `install_password`}} /add /passwordchg:no /passwordreq:yes /active:yes /Y" ,
                 "net localgroup Administrators {{user `install_user`}} /add",
                 "winrm set winrm/config/service/auth @{Basic=\"true\"}",
                 "winrm get winrm/config/service/auth"
+            ]
+        },
+        {
+            "type": "powershell",
+            "inline": [
+                "if (-not ((net localgroup Administrators) -contains '{{user `install_user`}}')) { exit 1 }"
             ]
         },
         {


### PR DESCRIPTION
To prevent from this error:
vhd: The password entered is longer than 14 characters.  Computers
vhd: with Windows prior to Windows 2000 will not be able to use
vhd: this account. Do you want to continue this operation? (Y/N) [Y]:

Because it fails the packer build later on in the process when scripts are installed as an elevated user.