### PR TITLE
Hosted Preview macOS image software updates week 35

### DIFF
--- a/images/macos/macos-Readme.md
+++ b/images/macos/macos-Readme.md
@@ -21,18 +21,18 @@ The following software is installed on machines in the VSTS **Hosted macOS Previ
 - Python 2.7.10
 - Python 3.7.0
 - Ruby 2.5.1p57
-- .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400
-- Go 1.10.3
+- .NET Core SDK 1.0.1, 1.0.4, 1.1.4, 1.1.5, 1.1.7, 1.1.8, 1.1.9, 2.0.0, 2.0.3, 2.1.100, 2.1.101, 2.1.102, 2.1.103, 2.1.104, 2.1.105, 2.1.2, 2.1.200, 2.1.201, 2.1.300, 2.1.301, 2.1.4, 2.1.400, 2.1.401
+- Go 1.11
 
 ### Package Management
 
 - Bundler 1.16.1
 - Carthage 0.30.1
 - CocoaPods 1.5.3
-- Homebrew 1.7.1
+- Homebrew 1.7.2
 - NPM 3.10.10
 - Yarn 1.9.4
-- NuGet 4.3.0.4406
+- NuGet 4.7.0.5148
 - pip 18.0
 - Miniconda 4.5.4
 
@@ -52,7 +52,7 @@ The following software is installed on machines in the VSTS **Hosted macOS Previ
 ### Tools
 
 - fastlane 2.102.0
-- App Center CLI 1.1.1
+- App Center CLI 1.1.2
 - Azure-CLI 2.0.44
 
 ### Pre-cached tools
@@ -448,10 +448,11 @@ The following software is installed on machines in the VSTS **Hosted macOS Previ
 
 ### Visual Studio for Mac
 
-- 7.5.2.40
+- 7.6.0.2188
 
 ### Mono
 
+- 5.12.0
 - 5.10.1
 - 5.8.1
 - 5.8.0
@@ -463,6 +464,7 @@ The following software is installed on machines in the VSTS **Hosted macOS Previ
 
 ### Xamarin.iOS SDK
 
+- 11.14.0.13
 - 11.12.0.4
 - 11.9.1.24
 - 11.8.0.20
@@ -474,6 +476,7 @@ The following software is installed on machines in the VSTS **Hosted macOS Previ
 
 ### Xamarin.Android SDK
 
+- 9.0.0-18
 - 8.3.3-2
 - 8.2.0-16
 - 8.2.0-15
@@ -485,6 +488,7 @@ The following software is installed on machines in the VSTS **Hosted macOS Previ
 
 ### Xamarin.Mac SDK
 
+- 4.6.0.13
 - 4.4.1.193
 - 4.2.1.28
 - 4.2.0.20


### PR DESCRIPTION
    Homebrew 1.7.2
    App Center CLI 1.1.2
    NET SDK 2.1.401
    Go 1.11
    NuGet Version: 4.7.0.5148

Visual Studio for Mac: 7.6.0.2188
Default Xamarin.iOS SDK Version: 11.14.0.13
Default Xamarin.Android SDK Version: 9.0.0-18
Default Xamarin.Mac SDK Version: 4.6.0.13
Default Mono Version: 5.12.0

Pre-cached packages: 08/26