### PR TITLE
Removing Java 9 from the Windows image

### DIFF
--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -7,7 +7,6 @@
 #Installing Both x86 and x64 versions of Java
 choco install jdk8 -params "both=true" -y
 
-choco install jdk9 -y
 choco install jdk10 -y
 choco install ant -y
 choco install maven -y
@@ -31,9 +30,6 @@ foreach ($pathSegment in $pathSegments)
 $java8Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter 'jdk*8*' | Sort-Object -Property Name -Descending | Select-Object -First 1
 $latestJava8Install = $java8Installs.FullName;
 
-$java9Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter 'jdk*9*' | Sort-Object -Property Name -Descending | Select-Object -First 1
-$latestJava9Install = $java9Installs.FullName;
-
 $java10Installs = Get-ChildItem -Path 'C:\Program Files\Java' -Filter 'jdk*10*' | Sort-Object -Property Name -Descending | Select-Object -First 1
 $latestJava10Install = $java10Installs.FullName;
 
@@ -44,7 +40,6 @@ Set-MachinePath -NewPath $newPath
 
 setx JAVA_HOME $latestJava8Install /M
 setx JAVA_HOME_8_X64 $latestJava8Install /M
-setx JAVA_HOME_9_X64 $latestJava9Install /M
 setx JAVA_HOME_10_X64 $latestJava10Install /M
 
 #Move maven variables to Machine, they may not be in the environment for this script so we need to read them from the registry.

--- a/images/win/scripts/Installers/Validate-JavaTools.ps1
+++ b/images/win/scripts/Installers/Validate-JavaTools.ps1
@@ -23,13 +23,6 @@ if( $( $(& $env:comspec "/s /c java -version 2>&1") | Out-String) -match  'java 
    $javaVersion = $Matches.version
 }
 
-$env:Path = $env:JAVA_HOME_9_X64 + "\bin;" + $env:Path
-
-if( $( $(& $env:comspec "/s /c java -version 2>&1") | Out-String) -match  'java version "(?<version>.*)".*' )
-{
-   $java9Version = $Matches.version
-}
-
 $env:Path = $env:JAVA_HOME_10_X64 + "\bin;" + $env:Path
 
 if( $( $(& $env:comspec "/s /c java -version 2>&1") | Out-String) -match  'java version "(?<version>.*)".*' )
@@ -62,10 +55,6 @@ $Description = @"
 _Environment:_
 * JAVA_HOME: location of JDK
 * PATH: contains bin folder of JDK
-
-#### $java9Version
-
-_Location:_ $env:JAVA_HOME_9_X64
 
 #### $java10Version
 


### PR DESCRIPTION
Removing Java 9 from the Windows image due to the package no longer being available. Users will be prompted to use the JavaToolInstaller task to install Java 9 if they need it.